### PR TITLE
fix spacing for space children in filter on program (tmp)

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -727,10 +727,12 @@ main.programm #filterline ul li:not(.back) {
   box-sizing: border-box;
   background: black;
   color: white;
+  /*
   max-width: 280px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  */
 }
 main.programm #filterline ul li a {
   color: white;
@@ -760,11 +762,28 @@ main.programm #filterline ul li.back span {
 main.programm #filterline ul li.back span:hover {
   opacity: 1;
 }
-main.programm #filterline ul + ul::before {
-  content: "↳ ";
+main.programm #filterline ul:last-of-type {
+  margin-top: 10px;
 }
-main.programm #filterline div > ul:last-of-type > ul {
-  padding-left: 1ex;
+main.programm #filterline ul:last-of-type > li {
+  border: 1px solid black;
+}
+main.programm #filterline ul:last-of-type > li:hover {
+  background-color: white;
+  border: 1px solid black;
+}
+main.programm #filterline ul:last-of-type > li:hover > a {
+  color: black;
+}
+main.programm #filterline ul + ul:not(:last-of-type)::before {
+  content: "\21B3\00A0";
+}
+main.programm #filterline ul:last-of-type > li:only-child {
+  background-color: white;
+  border: 1px solid black;
+}
+main.programm #filterline ul:last-of-type > li:only-child > a {
+  color: black;
 }
 main.programm #filterline .level {
   display: none;

--- a/views/de/program.hbs
+++ b/views/de/program.hbs
@@ -6,7 +6,7 @@
             <div>
                 {{#each filterParents as |parent|}}
                     {{#if parent.id}}
-                        <ul style="margin-left: calc({{@index}} * 20px)">
+                        <ul>
                             {{#if parent.id}}
                                 <li><a href="/programm/{{parent.id}}">{{parent.name}}</a></li>
                             {{/if}}
@@ -14,7 +14,7 @@
                         {{#greaterThan ../filterParents.length @index}}
                         {{else}}
                             {{#if ../filterData.children}}
-                                <ul style="margin-left: calc(({{@index}} + 1) * 20px)">
+                                <ul>
                                     {{#each ../filterData.children as |child|}}
                                         <li><a href="/programm/{{child.id}}">{{child.name}}</a></li>
                                     {{/each}}

--- a/views/en/program.hbs
+++ b/views/en/program.hbs
@@ -6,7 +6,7 @@
             <div>
                 {{#each filterParents as |parent|}}
                     {{#if parent.id}}
-                        <ul style="margin-left: calc({{@index}} * 20px)">
+                        <ul>
                             {{#if parent.id}}
                                 <li><a href="/en/programme/{{parent.id}}">{{parent.name}}</a></li>
                             {{/if}}
@@ -14,7 +14,7 @@
                         {{#greaterThan ../filterParents.length @index}}
                         {{else}}
                             {{#if ../filterData.children}}
-                                <ul style="margin-left: calc(({{@index}} + 1) * 20px)">
+                                <ul>
                                     {{#each ../filterData.children as |child|}}
                                         <li><a href="/en/programme/{{child.id}}">{{child.name}}</a></li>
                                     {{/each}}


### PR DESCRIPTION
@robertschnuell Filter still does not work for the very first filter element `Rundgang 2021` on `https://<domain>/en/programme`, and the same happens when the `Rundgang 2021` filter is active via: `https://<domain>/en/programme/!TCqCDYYsBUxmjWOZWV:<synapse_server_name>`